### PR TITLE
Update .gitmodules 'greg' URL to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "greg"]
 	path = greg
-	url = git://github.com/nddrylliog/greg.git
+	url = https://github.com/nddrylliog/greg.git
 [submodule "MarkdownTest"]
 	path = MarkdownTest
 	url = https://github.com/fletcher/MMD-Test-Suite.git


### PR DESCRIPTION
Updated 'greg' to use https:// URL instead of git://. The git:// URL can break support for users behind firewall or proxy and use of https:// is consistent with the other submodules, "MarkdownTest" and "Support". This will also not allow some users to install the homebrew MultiMarkdown-4 and this URL can only be edited in the MultiMarkdown-4 repo, not the homebrew formula.
