### PR TITLE
Version is defined in one place now.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 CFLAGS ?= -Wall -g -O3 -include GLibFacade.h
 PROGRAM = multimarkdown
 VERSION = 4.3.1
+override CFLAGS += -D MMD_VERSION='"$(VERSION)"'
 
 OBJS= multimarkdown.o parse_utilities.o parser.o GLibFacade.o writer.o text.o html.o latex.o memoir.o beamer.o opml.o odf.o critic.o
 

--- a/parser.h
+++ b/parser.h
@@ -14,8 +14,6 @@
 
 #define TABSTOP 4
 
-#define MMD_VERSION "4.3.1"
-
 #define MMD_COPYRIGHT \
 	"Copyright (c) 2013 Fletcher T. Penney.\n\n" \
 	"portions based on peg-markdown - Copyright (c) 2008-2009 John MacFarlane.\n" \


### PR DESCRIPTION
There were redundancy: multimarkdown version is specified in parser.h and in
makefile. This change removed version from parser.h, so the version is defined
in one location now. When you want to bump version, only one file should be
edited.

Makefile tricks explained:

```
override CFLAGS += -D MMD_VERSION='"$(VERSION)"'
```
1.  Without `override` asignment works only if CFLAGS is _not_ defined in the
   make command line.
2.  Double quotes are required because code expects MMD_VERSION is string.
3.  Single quotes are required to protect double quotes -- otherwise shell will
   strip double quotes.
