### PR TITLE
Fix a buffer overrun warning in Loose List parsing

### DIFF
--- a/parser.leg
+++ b/parser.leg
@@ -807,8 +807,9 @@ ListLoose = a:StartList
 		{
 			node *li;
 			li = b->children;
-			li->str = realloc(li->str, strlen(li->str) + 3);
-			strcat(li->str, "\n\n");  /* In loose list, \n\n added to end of each element */
+			size_t new_size = strlen(li->str) + 3;
+			li->str = realloc(li->str, new_size);
+			strncat(li->str, "\n\n", new_size);  /* In loose list, \n\n added to end of each element */
 			a = cons(b, a);
 		} )+
 		{ $$ = list(LIST, a); }


### PR DESCRIPTION
I get a bizarre memory read error originating from Loose List; it seems that strcat reads a bit more of the string than it should; I therefore replaced strcat with strncat, which fixes the error.
