### PR TITLE
removed whitespace emacs considers 'suspicious' (minor whitespace clean up)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ test-critic-accept: $(PROGRAM)
 test-critic-reject: $(PROGRAM)
 	cd MarkdownTest; \
 	./MarkdownTest.pl --Script=../$(PROGRAM) --testdir=CriticMarkup --Flags="-r" --ext=".htmlr"
-	
+
 test-all: $(PROGRAM) test test-mmd test-compat test-latex test-beamer test-memoir test-opml test-odf test-critic-accept test-critic-reject
 
 test-memory: $(PROGRAM)


### PR DESCRIPTION
removed whitespace at beginning of line 91. BSDMake mode in emacs considers this 'suspicious'.
