### PR TITLE
Added support for escaped line breaks.

### DIFF
--- a/libMultiMarkdown.h
+++ b/libMultiMarkdown.h
@@ -28,24 +28,25 @@ char * mmd_version(void);
 
 /* These are the basic extensions */
 enum parser_extensions {
-	EXT_COMPATIBILITY   = 1 << 0,    /* Markdown compatibility mode */
-	EXT_COMPLETE        = 1 << 1,    /* Create complete document */
-	EXT_SNIPPET         = 1 << 2,    /* Create snippet only */
-	EXT_HEAD_CLOSED     = 1 << 3,    /* for use by parser */
-	EXT_SMART           = 1 << 4,    /* Enable Smart quotes */
-	EXT_NOTES           = 1 << 5,    /* Enable Footnotes */
-	EXT_NO_LABELS       = 1 << 6,    /* Don't add anchors to headers, etc. */
-	EXT_FILTER_STYLES   = 1 << 7,    /* Filter out style blocks */
-	EXT_FILTER_HTML     = 1 << 8,    /* Filter out raw HTML */
-	EXT_PROCESS_HTML    = 1 << 9,    /* Process Markdown inside HTML */
-	EXT_NO_METADATA     = 1 << 10,   /* Don't parse Metadata */
-	EXT_OBFUSCATE       = 1 << 11,   /* Mask email addresses */
-	EXT_CRITIC          = 1 << 12,   /* Critic Markup Support */
-	EXT_CRITIC_ACCEPT   = 1 << 13,   /* Accept all proposed changes */
-	EXT_CRITIC_REJECT   = 1 << 14,   /* Reject all proposed changes */
-	EXT_RANDOM_FOOT     = 1 << 15,   /* Use random numbers for footnote links */
-	EXT_HEADINGSECTION  = 1 << 16,   /* Group blocks under parent heading */
-	EXT_FAKE            = 1 << 31,   /* 31 is highest number allowed */
+	EXT_COMPATIBILITY       = 1 << 0,    /* Markdown compatibility mode */
+	EXT_COMPLETE            = 1 << 1,    /* Create complete document */
+	EXT_SNIPPET             = 1 << 2,    /* Create snippet only */
+	EXT_HEAD_CLOSED         = 1 << 3,    /* for use by parser */
+	EXT_SMART               = 1 << 4,    /* Enable Smart quotes */
+	EXT_NOTES               = 1 << 5,    /* Enable Footnotes */
+	EXT_NO_LABELS           = 1 << 6,    /* Don't add anchors to headers, etc. */
+	EXT_FILTER_STYLES       = 1 << 7,    /* Filter out style blocks */
+	EXT_FILTER_HTML         = 1 << 8,    /* Filter out raw HTML */
+	EXT_PROCESS_HTML        = 1 << 9,    /* Process Markdown inside HTML */
+	EXT_NO_METADATA         = 1 << 10,   /* Don't parse Metadata */
+	EXT_OBFUSCATE           = 1 << 11,   /* Mask email addresses */
+	EXT_CRITIC              = 1 << 12,   /* Critic Markup Support */
+	EXT_CRITIC_ACCEPT       = 1 << 13,   /* Accept all proposed changes */
+	EXT_CRITIC_REJECT       = 1 << 14,   /* Reject all proposed changes */
+	EXT_RANDOM_FOOT         = 1 << 15,   /* Use random numbers for footnote links */
+	EXT_HEADINGSECTION      = 1 << 16,   /* Group blocks under parent heading */
+	EXT_ESCAPED_LINE_BREAKS = 1 << 17,   /* Escaped line break */
+	EXT_FAKE                = 1 << 31,   /* 31 is highest number allowed */
 };
 
 /* Define output formats we support -- first in list is default */

--- a/multimarkdown.c
+++ b/multimarkdown.c
@@ -39,6 +39,7 @@ int main(int argc, char **argv)
 	static int no_typography_flag = 0;
 	static int label_flag = 0;
 	static int no_label_flag = 0;
+	static int escaped_line_breaks_flag = 0;
 	static int obfuscate_flag = 0;
 	static int no_obfuscate_flag = 0;
 	static int process_html_flag = 0;
@@ -47,28 +48,29 @@ int main(int argc, char **argv)
 	char *target_meta_key = FALSE;
 		
 	static struct option long_options[] = {
-		{"batch", no_argument, &batch_flag, 1},                    /* process each file separately */
-		{"to", required_argument, 0, 't'},                         /* which output format to use */
-		{"full", no_argument, &complete_flag, 1},                  /* complete document */
-		{"snippet", no_argument, &snippet_flag, 1},                /* snippet only */
-		{"output", required_argument, 0, 'o'},                     /* which output format to use */
-		{"notes", no_argument, &notes_flag, 1},                    /* use footnotes */
-		{"nonotes", no_argument, &no_notes_flag, 1},               /* don't use footnotes */
-		{"smart", no_argument, &typography_flag, 1},               /* use smart typography */
-		{"nosmart", no_argument, &no_typography_flag, 1},          /* don't use smart typography */
-		{"mask", no_argument, &obfuscate_flag, 1},                 /* mask email addresses */
-		{"nomask", no_argument, &no_obfuscate_flag, 1},            /* don't mask email addresses */
-		{"labels", no_argument, &label_flag, 1},                   /* generate labels */
-		{"nolabels", no_argument, &no_label_flag, 1},              /* don't generate labels */
-		{"compatibility", no_argument, &compatibility_flag, 1},    /* compatibility mode */
-		{"process-html", no_argument, &process_html_flag, 1},      /* process Markdown inside HTML */
-		{"random", no_argument, &random_footnotes_flag, 1},        /* Use random numbers for footnote links */
-		{"accept", no_argument, 0, 'a'},                           /* Accept all proposed CriticMarkup changes */
-		{"reject", no_argument, 0, 'r'},                           /* Reject all proposed CriticMarkup changes */
-		{"metadata-keys", no_argument, 0, 'm'},                    /* List all metadata keys */
-		{"extract", required_argument, 0, 'e'},                    /* show value of specified metadata */
-		{"version", no_argument, 0, 'v'},                          /* display version information */
-		{"help", no_argument, 0, 'h'},                             /* display usage information */
+		{"batch", no_argument, &batch_flag, 1},                              /* process each file separately */
+		{"to", required_argument, 0, 't'},                                   /* which output format to use */
+		{"full", no_argument, &complete_flag, 1},                            /* complete document */
+		{"snippet", no_argument, &snippet_flag, 1},                          /* snippet only */
+		{"output", required_argument, 0, 'o'},                               /* which output format to use */
+		{"notes", no_argument, &notes_flag, 1},                              /* use footnotes */
+		{"nonotes", no_argument, &no_notes_flag, 1},                         /* don't use footnotes */
+		{"smart", no_argument, &typography_flag, 1},                         /* use smart typography */
+		{"nosmart", no_argument, &no_typography_flag, 1},                    /* don't use smart typography */
+		{"mask", no_argument, &obfuscate_flag, 1},                           /* mask email addresses */
+		{"nomask", no_argument, &no_obfuscate_flag, 1},                      /* don't mask email addresses */
+		{"labels", no_argument, &label_flag, 1},                             /* generate labels */
+		{"nolabels", no_argument, &no_label_flag, 1},                        /* don't generate labels */
+		{"escaped-line-breaks", no_argument, &escaped_line_breaks_flag, 1},  /* enable escaped line breaks */
+		{"compatibility", no_argument, &compatibility_flag, 1},              /* compatibility mode */
+		{"process-html", no_argument, &process_html_flag, 1},                /* process Markdown inside HTML */
+		{"random", no_argument, &random_footnotes_flag, 1},                  /* Use random numbers for footnote links */
+		{"accept", no_argument, 0, 'a'},                                     /* Accept all proposed CriticMarkup changes */
+		{"reject", no_argument, 0, 'r'},                                     /* Reject all proposed CriticMarkup changes */
+		{"metadata-keys", no_argument, 0, 'm'},                              /* List all metadata keys */
+		{"extract", required_argument, 0, 'e'},                              /* show value of specified metadata */
+		{"version", no_argument, 0, 'v'},                                    /* display version information */
+		{"help", no_argument, 0, 'h'},                                       /* display usage information */
 		{NULL, 0, NULL, 0}
 	};
 	
@@ -144,7 +146,8 @@ int main(int argc, char **argv)
 				"    --notes, --nonotes     Toggle footnotes\n"
 				"    --labels, --nolabels   Disable id attributes for headers\n"
 				"    --mask, --nomask       Mask email addresses in HTML\n"
-				
+				"    --escaped-line-breaks  Enable escaped line breaks\n"
+
 				"\nAvailable FORMATs: html(default), latex, beamer, memoir, odf, opml, lyx\n\n"
 				"NOTE: The lyx output format was created by Charles R. Cowan, and \n\tis provided as is.\n\n\n"
 				);
@@ -251,6 +254,9 @@ int main(int argc, char **argv)
 	
 	if (random_footnotes_flag)
 		extensions = extensions | EXT_RANDOM_FOOT;
+
+	if (escaped_line_breaks_flag)
+		extensions = extensions | EXT_ESCAPED_LINE_BREAKS;
 
 	/* Enable HEADINGSECTION for certain formats */
 	if ((output_format == OPML_FORMAT) || (output_format == BEAMER_FORMAT) || (output_format == LYX_FORMAT))

--- a/parser.leg
+++ b/parser.leg
@@ -332,10 +332,10 @@ NormalEndline =   Sp Newline !BlankLine !'>' !AtxStart
 TerminalEndline = Sp Newline Eof
 		{ $$ = NULL; }
 
-LineBreak = ("  " | &{ !ext(EXT_COMPATIBILITY) } "\\") a:NormalEndline
+LineBreak = ("  " | &{ !ext(EXT_COMPATIBILITY) && ext(EXT_ESCAPED_LINE_BREAKS) } Sp "\\") a:NormalEndline
 		{ $$ = a; $$->key = LINEBREAK; }
 
-voidEndline = (("  " | &{ !ext(EXT_COMPATIBILITY) } "\\") voidNormalEndline) | (Sp Newline Eof) | voidNormalEndline
+voidEndline = (("  " | &{ !ext(EXT_COMPATIBILITY) && ext(EXT_ESCAPED_LINE_BREAKS) } Sp "\\") voidNormalEndline) | (Sp Newline Eof) | voidNormalEndline
 
 voidNormalEndline = Sp Newline !BlankLine !'>' !AtxStart
 		!(RawLine ('='+ | '-'+) Newline)


### PR DESCRIPTION
Hi,
I have added support for escaped line breaks, i.e. a backslash followed by a newline is also a hard line break.

This is useful with editors that automatically strip trailing spaces.
