### PR TITLE
Fix bug when processing several files in batch mode with latexmode metadata set

### DIFF
--- a/multimarkdown.c
+++ b/multimarkdown.c
@@ -327,6 +327,7 @@ int main(int argc, char **argv)
 				free(temp);
 			}
 			free(target_meta_key);
+			target_meta_key = NULL;
 
 			out = markdown_to_string(inputbuf->str,  extensions, output_format);
 			


### PR DESCRIPTION
If several files are processed in batch mode and one the first files has the latexmode metadata set, multimarkdown will dereference a previously freed pointer, which can make it crash.

When the file with the latexmode metadata is processed, target_meta_key is set to point to this metadata (multimarkdown.c:321) and then freed (multimarkdown.c:329). However, it is not reset to null, so when the next file
is processed, target_meta_key still points to freed metadata and is accessed in extract_metadata_value (multimarkdown.c:304).
