### PR TITLE
Quote paths in Windows batch scripts

### DIFF
--- a/windows_installer/mmd.bat
+++ b/windows_installer/mmd.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 :Loop
 IF "%1"=="" GOTO Continue
-   %~dp0\multimarkdown -b %1
+   "%~dp0\multimarkdown" -b %1
 SHIFT
 GOTO Loop
 :Continue

--- a/windows_installer/mmd2odf.bat
+++ b/windows_installer/mmd2odf.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 :Loop
 IF "%1"=="" GOTO Continue
-   %~dp0\multimarkdown -b -t odf %1
+   "%~dp0\multimarkdown" -b -t odf %1
 SHIFT
 GOTO Loop
 :Continue

--- a/windows_installer/mmd2opml.bat
+++ b/windows_installer/mmd2opml.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 :Loop
 IF "%1"=="" GOTO Continue
-   %~dp0\multimarkdown -b -t opml %1
+   "%~dp0\multimarkdown" -b -t opml %1
 SHIFT
 GOTO Loop
 :Continue

--- a/windows_installer/mmd2rtf.bat
+++ b/windows_installer/mmd2rtf.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 :Loop
 IF "%1"=="" GOTO Continue
-   %~dp0\multimarkdown -b -t rtf %1
+   "%~dp0\multimarkdown" -b -t rtf %1
 SHIFT
 GOTO Loop
 :Continue

--- a/windows_installer/mmd2tex.bat
+++ b/windows_installer/mmd2tex.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 :Loop
 IF "%1"=="" GOTO Continue
-   %~dp0\multimarkdown -b -t latex %1
+   "%~dp0\multimarkdown" -b -t latex %1
 SHIFT
 GOTO Loop
 :Continue


### PR DESCRIPTION
Add quotes around the file paths in the Windows batch scripts to support base directories with spaces (e.g. "C:\Program Files\MultiMarkdown").
