### PR TITLE
Fix vanishing MMD-starting image caption

### DIFF
--- a/html.c
+++ b/html.c
@@ -544,10 +544,15 @@ void print_html_node(GString *out, node *n, scratch_pad *scratch) {
 			}
 			g_string_append_printf(out, " />");
 			if (n->key == IMAGEBLOCK) {
-				if ((n->children != NULL) && (n->children->children != NULL) && (n->children->children->str != NULL)) {
-					g_string_append_printf(out, "\n<figcaption>");
-					print_html_node(out,n->children,scratch);
-					g_string_append_printf(out, "</figcaption>");
+				if (n->children != NULL) {
+					temp_str = g_string_new("");
+					print_html_node(temp_str,n->children,scratch);
+					if (temp_str->currentStringLength > 0) {
+						g_string_append_printf(out, "\n<figcaption>");
+						g_string_append(out, temp_str->str);
+						g_string_append_printf(out, "</figcaption>");
+					}
+					g_string_free(temp_str, true);
 				}
 				g_string_append_printf(out,"\n</figure>");
 				scratch->padded = 0;


### PR DESCRIPTION
This MMD code should have a `<figcaption>` tag when parsed, but doesn’t:

```
![*test* me](http://example.com/)
```

This one does, though (notice the leading whitespace):

```
![ *test* me](http://example.com/)
```

In short, if the first caption character is part of the MMD syntax, it vanishes completely; this should fix it while keeping #58 in place.
