### PR TITLE
Add support for "make DESTDIR=..." for packagers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,14 +42,14 @@ $(GREG): greg
 $(PROGRAM) : $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS)
 
-install: $(PROGRAM) | $(DESTDIR)$(prefix)/bin
-	install -m 0755 multimarkdown $(DESTDIR)$(prefix)/bin
+install: $(PROGRAM) | $(prefix)/bin
+	install -m 0755 multimarkdown $(prefix)/bin
 
-$(DESTDIR)$(prefix)/bin:
-	-mkdir -p $(DESTDIR)$(prefix)/bin  2>/dev/null
+$(prefix)/bin:
+	-mkdir $(prefix)/bin  2>/dev/null
 
 install-scripts:
-	install -m 0755 scripts/* $(DESTDIR)$(prefix)/bin
+	install -m 0755 scripts/* $(prefix)/bin
 
 pkg-install: $(PROGRAM) | $(DESTDIR)$(prefix)/bin
 	install -m 0755 multimarkdown $(DESTDIR)$(prefix)/bin


### PR DESCRIPTION
This commit adds support for using `DESTDIR`, which is used by software packagers when building RPMs and other packages. When `DESTDIR` is set, it is used as a prefix for the install path, but when unset, the software installs to the system path (in this case, `/usr/local/bin`).

Example usage taken from an RPM spec file:

```
make install DESTDIR=%{buildroot}
```

This is important when packaging because you need to install the output to a contained area in order to build a clean package from it, rather than install onto the system and then attempt to pick the files back out to package them.
