### PR TITLE
beamer: if a frame contains a code block, it must be marked as fragile

### DIFF
--- a/beamer.c
+++ b/beamer.c
@@ -63,7 +63,8 @@ void print_beamer_node(GString *out, node *n, scratch_pad *scratch) {
 				pad(out, 2, scratch);
 				g_string_append_printf(out, "\\begin{frame}");
 				/* TODO: Fix this */
-				if (tree_contains_key(n->children,VERBATIM)) {
+				if (tree_contains_key(n->children,VERBATIM) ||
+				    tree_contains_key(n->children,VERBATIMFENCE)) {
 					g_string_append_printf(out, "[fragile]");
 				}
 				scratch->padded = 0;


### PR DESCRIPTION
Hi Fletcher, latest mmd from repo has a bug where it doesn't add 'fragile' to a beamer frame that contains a code block, so LaTeX then fails. This patch fixes it.