### PR TITLE
Patches from the OpenBSD port of MultiMarkdown 4.7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,14 @@ ifeq ($(MAKECMDGOALS),static)
 LDFLAGS += -static -static-libgcc
 endif
 
-GREG= greg/greg
+# OUR_GREG: the version of greg in a submodule
+# GREG: the path to greg we want to use for parser.leg
+#
+# This way we can pass GREG=/usr/local/bin/greg in on
+# the command line if we have greg installed already.
+
+OUR_GREG=greg/greg
+GREG?=$(OUR_GREG)
 
 ALL : $(PROGRAM) enumMap.txt
 static : $(PROGRAM) enumMap.txt
@@ -40,10 +47,10 @@ static : $(PROGRAM) enumMap.txt
 %.o : %.c parser.h
 	$(CC) -c $(CFLAGS) -o $@ $<
 
-parser.c : parser.leg greg/greg parser.h
-	greg/greg -o parser.c parser.leg
+parser.c : parser.leg $(GREG) parser.h
+	$(GREG) -o parser.c parser.leg
 
-$(GREG): greg
+$(OUR_GREG): greg
 	$(MAKE) -C greg
 
 $(PROGRAM) : $(OBJS)

--- a/html.c
+++ b/html.c
@@ -112,8 +112,12 @@ void print_html_node(GString *out, node *n, scratch_pad *scratch) {
 				scratch->footnote_para_counter --;
 				if (scratch->footnote_para_counter == 0) {
 					if (scratch->extensions & EXT_RANDOM_FOOT) {
+#ifdef HAVE_ARC4RANDOM
+						random = arc4random_uniform(99999) + 1;
+#else
 						srand(scratch->random_seed_base + scratch->footnote_to_print);
 						random = rand() % 99999 + 1;
+#endif
 					} else {
 						random = scratch->footnote_to_print;
 					}
@@ -574,8 +578,12 @@ void print_html_node(GString *out, node *n, scratch_pad *scratch) {
 			temp_node = node_for_count(scratch->used_notes, lev);
 			
 			if (scratch->extensions & EXT_RANDOM_FOOT) {
+#ifdef HAVE_ARC4RANDOM
+				random = arc4random_uniform(99999) + 1;
+#else
 				srand(scratch->random_seed_base + lev);
 				random = rand() % 99999 + 1;
+#endif
 			} else {
 				random = lev;
 			}
@@ -628,8 +636,12 @@ void print_html_node(GString *out, node *n, scratch_pad *scratch) {
 					fprintf(stderr, "matching cite found - %d\n",lev);
 #endif
 					if (scratch->extensions & EXT_RANDOM_FOOT) {
+#ifdef HAVE_ARC4RANDOM
+						random = arc4random_uniform(99999) + 1;
+#else
 						srand(scratch->random_seed_base + lev);
 						random = rand() % 99999 + 1;
+#endif
 					} else {
 						random = lev;
 					}
@@ -901,8 +913,12 @@ void print_html_endnotes(GString *out, scratch_pad *scratch) {
 		pad(out, 1, scratch);
 		
 		if (scratch->extensions & EXT_RANDOM_FOOT) {
+#ifdef HAVE_ARC4RANDOM
+			random = arc4random_uniform(99999) + 1;
+#else
 			srand(scratch->random_seed_base + counter);
 			random = rand() % 99999 + 1;
+#endif
 		} else {
 			random = counter;
 		}

--- a/latex.c
+++ b/latex.c
@@ -1202,16 +1202,16 @@ void print_latex_url(GString *out, char *str, scratch_pad *scratch) {
 char * correct_dimension_units(char *original) {
 	char *result;
 	int i;
-	
+	size_t result_len;
+
 	result = strdup(original);
-	
+	result_len = strlen(result);
+
 	for (i = 0; result[i]; i++)
 		result[i] = tolower(result[i]);
 	
-	if (strstr(&result[strlen(result)-2],"px")) {
-		result[strlen(result)-2] = '\0';
-		strcat(result, "pt");
-	}
+	if (strstr(&result[result_len-2],"px"))
+		result[result_len-1] = 't';
 	
 	return result;
 }

--- a/parse_utilities.c
+++ b/parse_utilities.c
@@ -22,7 +22,9 @@
 #include "parser.h"
 #include <libgen.h>
 
+#ifndef __OpenBSD__
 #pragma mark - Parse Tree
+#endif /* __OpenBSD__ */
 
 /* Create a new node in the parse tree */
 node * mk_node(int key) {
@@ -219,7 +221,9 @@ void append_list(node *new, node *list) {
 	}
 }
 
+#ifndef __OpenBSD__
 #pragma mark - Parser Data
+#endif /* __OpenBSD__ */
 
 /* Create parser data - this is where you stash stuff to communicate 
 	into and out of the parser */
@@ -250,7 +254,9 @@ void free_parser_data(parser_data *data) {
 }
 
 /* mk_scratch_pad -- store stuff here while exporting the result tree */
+#ifndef HAVE_ARC4RANDOM
 void ran_start(long seed);
+#endif
 scratch_pad * mk_scratch_pad(unsigned long extensions) {
 	scratch_pad *result = (scratch_pad *)malloc(sizeof(scratch_pad));
 	result->extensions = extensions;
@@ -277,6 +283,7 @@ scratch_pad * mk_scratch_pad(unsigned long extensions) {
 	result->table_alignment = NULL;
 	result->table_column = 0;
 
+#ifndef HAVE_ARC4RANDOM
 	if (extensions & EXT_RANDOM_FOOT) {
 	    srand((int)time(NULL));
 		result->random_seed_base = rand() % 32000;
@@ -285,6 +292,7 @@ scratch_pad * mk_scratch_pad(unsigned long extensions) {
 		result->random_seed_base = 0;
 	}
 	ran_start(310952L);
+#endif /* !HAVE_ARC4RANDOM */
 	
 	result->lyx_para_type = PARA;             /* CRC - Simple paragraph */
 	result->lyx_level = 0;                    /* CRC - out outside level */

--- a/parser.leg
+++ b/parser.leg
@@ -562,8 +562,10 @@ AutoLinkUrl =   '<' < [A-Za-z]+ "://" ( !Newline !'>' . )+ > '>'
 
 AutoLinkEmail = '<' ( "mailto:" )? < [-A-Za-z0-9+_./!%~$]+ '@' ( !Newline !'>' . )+ > '>'
 	{
-		char *mailto = malloc(strlen(yytext) + 8);
-		sprintf(mailto, "mailto:%s", yytext);
+		size_t mailto_len = strlen(yytext) + 8;
+		char *mailto = malloc(mailto_len);
+		assert(mailto);
+		assert(snprintf(mailto,mailto_len,"mailto:%s",yytext) < mailto_len);
 		$$ = mk_link(str(yytext), NULL, mailto, NULL, NULL);
 		free(mailto);
 	}

--- a/writer.c
+++ b/writer.c
@@ -648,6 +648,7 @@ char * dimension_for_attribute(char *querystring, node *list) {
     int i;
     char *upper;
     GString *result;
+    size_t dimension_len;
 
     attribute = node_for_attribute(querystring, list);
     if (attribute == NULL) return NULL;
@@ -655,6 +656,7 @@ char * dimension_for_attribute(char *querystring, node *list) {
 	fprintf(stderr, "a\n");
 #endif
 
+    dimension_len = strlen(attribute->children->str);
     dimension = strdup(attribute->children->str);
     upper = strdup(attribute->children->str);
 
@@ -667,15 +669,13 @@ char * dimension_for_attribute(char *querystring, node *list) {
 	fprintf(stderr, "b\n");
 #endif
 
-    if (strstr(dimension, "px")) {
-        ptr = strstr(dimension,"px");
-        ptr[0] = '\0';
-        strcat(ptr,"pt");
-    }
+    ptr = strstr(dimension, "px");
+    if (ptr)
+        ptr[1] = 't';
 
     result = g_string_new(dimension);
     
-    if ((strcmp(dimension,upper) == 0) && (dimension[strlen(dimension) -1] != '%')) {
+    if ((strcmp(dimension,upper) == 0) && (dimension[dimension_len-1] != '%')) {
         /* no units */
         g_string_append_printf(result, "pt");
     }


### PR DESCRIPTION
Hi!  I've done a port of MultiMarkdown to OpenBSD so that it can be
part of the standard set of 3rd party open-source packages available
to all OpenBSD users.  I love what you've done and use it on a daily
basis - it has changed my feeling about LaTeX immeasurably.

Not only has it made me happier as a writer, it also introduced me to
Parsing Expression Grammars, which impressed me so much I wrote a
little blog post about it:
  http://trac.haqistan.net/blog/adventures-ports-parsing-expression-grammars

If for nothing else thanks for introducing me to this concept.

In doing the port I needed to make several patches, either for the
sake of the OpenBSD ports build system or to quell warnings from the
toolchain.

Makefile: The OpenBSD ports system doesn't really support git
submodules; since I was interested in greg anyway I did an independent
port of it (which has been accepted, my first!), so on OpenBSD I can
make the MultiMarkdown port depend on the greg port and we can use the
version of greg installed in /urs/local/bin.  To make this work, I
split GREG into OUR_GREG (greg/greg) and GREG (which defaults to
${OUR_GREG}) so that we can pass in GREG=/usr/local/bin/greg in the
make invocation to pick up the installed version of greg without
disrupting how the makefile works when you use the git submodule
instead.

html.c: Conditionally switch from rand() et al to arc4random(3).  For
reference: http://marc.info/?l=openbsd-tech&m=141807224826859 is an
email sent by Theo de Raadt to the tech@openbsd.org mailing list
summarizing his research on rand(), srand(), et. al.  OpenBSD has
pioneered the use of arc4random() and it is a good idea to use it when
available if you really want random numbers.  I've added a
HAVE_ARC4RANDOM #ifdef and turn it on from the OpenBSD port's
makefile.

latex.c: Quell linker warnings on OpenBSD about strcat; it is a good
idea to avoid it anyway but in this case it's actually shorter without
strcat(), so double win.

parse_utilities.c: #ifdef out #pragma's that don't work under OpenBSD
(#pragma mark is unsupported).  While I was in there I also did some
more arc4random() #ifdef's

parser.leg: Quell linker warning on OpenBSD about sprintf; snprintf()
is safer.

writer.c: Similar changes as for latex.c: codeis shorter, no strcat
warnings.

I hope you find at least some of these patches acceptable.  In any
event I'm glad to see you are actively developing MMD and hope
you continue.

Cheers, -A
