### PR TITLE
Facilitate easy reference to static library header

### DIFF
--- a/MultiMarkdown.xcodeproj/project.pbxproj
+++ b/MultiMarkdown.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		5AE59DBD172A14D600401A65 /* memoir.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A2534F1172768A8003D1A91 /* memoir.c */; };
 		5AE59DBE172A14D600401A65 /* opml.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A2534F3172768A8003D1A91 /* opml.c */; };
 		5AE59DBF172A14D600401A65 /* odf.c in Sources */ = {isa = PBXBuildFile; fileRef = 5A89852C17297DFB00D1D72D /* odf.c */; };
+		65A9F7421B99CFE600474F56 /* libMultiMarkdown.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A60F8FF172C099100EFBF5B /* libMultiMarkdown.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -208,6 +209,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5A1FF04A186A1724002544C0 /* lyxbeamer.h in Headers */,
+				65A9F7421B99CFE600474F56 /* libMultiMarkdown.h in Headers */,
 				5A50A7591ADDFE600069AFD5 /* toc.h in Headers */,
 				5A56E587186CE833004089C0 /* transclude.h in Headers */,
 				5A1FF045186A16D3002544C0 /* lyx.h in Headers */,
@@ -434,6 +436,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = StaticLibraryHeaders/MultiMarkdown;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};
@@ -469,6 +472,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = StaticLibraryHeaders/MultiMarkdown;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};

--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ Once installed, you simply do something like the following:
 * `multimarkdown -b *.txt` --- `-b` or `--batch` mode can process multiple files at once, converting `file.txt` to `file.html` or `file.tex` as directed. Using this feature, you can convert a directory of MultiMarkdown text files into HTML files, or LaTeX files with a single command without having to specify the output files manually. **CAUTION**: This will overwrite existing files with the `html` or `tex` extension, so use with caution. 
 
 
+# Static Library Usage #
+
+If you wish to link MultiMarkdown with another Xcode based project, drag the MultiMarkdown.xcodeproj file to the project navigator to make a reference to it, then add the MultiMarkdown static library product as a project dependency and as a linked library.
+
+The public interface to the MultiMarkdown static library is described in libMultiMarkdown.h, which you can include from your project by adding the build setting:
+
+```
+HEADER_SEARCH_PATHS = $(CONFIGURATION_BUILD_DIR)/StaticLibraryHeaders
+```
+
+And then including into whichever source file needs access to MultiMarkdown:
+
+```
+#include <MultiMarkdown/libMultiMarkdown.h>
+```
+
 # Notes #
 
 If you get an error that `greg` fails to build try `touch greg/greg.c`.  I had an issue where the timestamp on that file might have been too old, which caused the build to fail.


### PR DESCRIPTION
Hi Fletcher - the gist of this request is to add support for easily importing MultiMarkdown's header from a project that depends upon MultiMarkdown. I don't know if you have another solution you already prefer, but this one seems pretty canonical and makes it easy for projects to add the resulting headers from the static library target as they see fit.
