### PR TITLE
Quiet warning about implicit downcasting from long to int. 

### DIFF
--- a/transclude.c
+++ b/transclude.c
@@ -118,7 +118,7 @@ void transclude_source(GString *source, char *basedir, char *stack, int output_f
 	size_t pos;
 	char real[1000];
 	FILE *input;
-	int offset;
+	long offset;
 
 	if (basedir == NULL) {
 		base = strdup("");


### PR DESCRIPTION
It seems like using a long variable here is the most straightforward solution, even though the offset is always expected to be relatively small, the long variable type prevents us having to cast the result of the pointer math.